### PR TITLE
Fix RPM presicion issue

### DIFF
--- a/hr4988.c
+++ b/hr4988.c
@@ -138,5 +138,5 @@ void changeRotation(void){
 }
 
 void setSpeed(uint16_t speed){
-  TIM1_SetFrequency((speed / 60) * stepsPerRevolution);
+  TIM1_SetFrequency(((uint32_t)((uint32_t)speed * stepsPerRevolution) * 1092)  >> 16);
 }


### PR DESCRIPTION
Fix the presicion issue with RPM tuning by utilizing fixed-point operations on a "Q16" base, and replacing the division by a multiplication of its inverse on fixed-point. This way, the division can be replaced by a (fast) multiplication and a later bit shift by Q (16).

Close #1 